### PR TITLE
Fix: cli init + hello commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Frame 1](https://cdn.jsdelivr.net/gh/gaurangrshah/_shots@master/uPic/2024/Frame%201.jpg)
+
 <h1 align="center">♨️ Node CLI Boilerplate</h1>
 
 <div align="center">

--- a/package.json
+++ b/package.json
@@ -1,59 +1,59 @@
 {
-	"name": "@boilertown/node-cli-boilerplate",
-	"version": "0.0.0",
-	"description": "Your Node.js CLI app",
-	"type": "module",
-	"bin": "./dist/index.js",
-	"engines": {
-		"node": ">=14.16"
-	},
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"cli": "node dist/index.js",
-		"build": "rm -rf dist && tsup src/index.ts --format esm --clean --minify --metafile",
-		"dev": "tsup src/index.ts --format esm --watch --clean --onSuccess \"node dist/index.js\"",
-		"test": "vitest",
-		"prepare": "husky install",
-		"changeset": "changeset",
-		"release": "changeset publish"
-	},
-	"dependencies": {
-		"@antfu/ni": "^0.21.4",
-		"chalk": "^5.2.0",
-		"commander": "^9.5.0",
-		"execa": "^7.0.0",
-		"figlet": "^1.5.2",
-		"ora": "^6.1.2"
-	},
-	"devDependencies": {
-		"@changesets/cli": "^2.26.0",
-		"@commitlint/cli": "^17.4.1",
-		"@commitlint/config-conventional": "^17.4.0",
-		"@trivago/prettier-plugin-sort-imports": "^4.0.0",
-		"@types/figlet": "^1.5.5",
-		"@types/node": "^18.11.18",
-		"@typescript-eslint/eslint-plugin": "^5.48.1",
-		"@typescript-eslint/parser": "^5.48.1",
-		"eslint": "^8.31.0",
-		"eslint-config-prettier": "^8.6.0",
-		"eslint-plugin-prettier": "^4.2.1",
-		"husky": "^8.0.3",
-		"lint-staged": "^13.1.0",
-		"prettier": "^2.8.2",
-		"tsup": "^6.5.0",
-		"type-fest": "^3.5.1",
-		"typescript": "^4.9.4",
-		"vitest": "^0.27.1"
-	},
-	"lint-staged": {
-		"*.{js,jsx,ts,tsx}": [
-			"eslint --fix",
-			"prettier --write"
-		],
-		"*.{md,mdx,yml,json}": [
-			"prettier --write"
-		]
-	}
+  "name": "@boilertown/node-cli-boilerplate",
+  "version": "0.0.0",
+  "description": "Your Node.js CLI app",
+  "type": "module",
+  "bin": "./dist/index.js",
+  "engines": {
+    "node": ">=14.16"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "cli": "node dist/index.js",
+    "build": "rm -rf dist && tsup src/index.ts --format esm --clean --minify --metafile",
+    "dev": "tsup src/index.ts --format esm --watch --clean --onSuccess \"node dist/index.js\"",
+    "test": "vitest",
+    "prepare": "husky install",
+    "changeset": "changeset",
+    "release": "changeset publish"
+  },
+  "dependencies": {
+    "@antfu/ni": "^0.21.12",
+    "chalk": "^5.3.0",
+    "commander": "^9.5.0",
+    "execa": "^7.2.0",
+    "figlet": "^1.7.0",
+    "ora": "^6.3.1"
+  },
+  "devDependencies": {
+    "@changesets/cli": "^2.26.0",
+    "@commitlint/cli": "^17.4.1",
+    "@commitlint/config-conventional": "^17.4.0",
+    "@trivago/prettier-plugin-sort-imports": "^4.0.0",
+    "@types/figlet": "^1.5.5",
+    "@types/node": "^18.11.18",
+    "@typescript-eslint/eslint-plugin": "^5.48.1",
+    "@typescript-eslint/parser": "^5.48.1",
+    "eslint": "^8.31.0",
+    "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "husky": "^8.0.3",
+    "lint-staged": "^13.1.0",
+    "prettier": "^2.8.2",
+    "tsup": "^6.5.0",
+    "type-fest": "^3.5.1",
+    "typescript": "^4.9.4",
+    "vitest": "^0.27.1"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{md,mdx,yml,json}": [
+      "prettier --write"
+    ]
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,22 +6,22 @@ settings:
 
 dependencies:
   '@antfu/ni':
-    specifier: ^0.21.4
+    specifier: ^0.21.12
     version: 0.21.12
   chalk:
-    specifier: ^5.2.0
+    specifier: ^5.3.0
     version: 5.3.0
   commander:
     specifier: ^9.5.0
     version: 9.5.0
   execa:
-    specifier: ^7.0.0
+    specifier: ^7.2.0
     version: 7.2.0
   figlet:
-    specifier: ^1.5.2
+    specifier: ^1.7.0
     version: 1.7.0
   ora:
-    specifier: ^6.1.2
+    specifier: ^6.3.1
     version: 6.3.1
 
 devDependencies:

--- a/src/commands/hello.ts
+++ b/src/commands/hello.ts
@@ -1,24 +1,26 @@
 // import figlet from 'figlet';
 
-// import path from 'path'; 
+// import path from 'path';
 
-import { Command } from 'commander';
+import { Command } from "commander";
+import fs from "fs";
+import path from "path";
 
 export const helloCommand = new Command()
-  .name('hello')
-  .description('Prints a greeting message')
+  .name("hello")
+  .description("Prints a greeting message")
   .action(() => {
     renderTitle();
   });
- async function loadScaffoldDependencies(): Promise<string[]> {
-    const packageJsonPath = '/coding/scaffold_2024/package.json'; 
-    const packageJson = await import(packageJsonPath);
-    return Object.keys(packageJson.dependencies);
-  }
+async function loadScaffoldDependencies(): Promise<string[]> {
+  const packageJsonPath = path.join(process.cwd(), "package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+  return Object.keys(packageJson.dependencies);
+}
 
 export const renderTitle = () => {
-	// const text = figlet.textSync('HEllO !', {
-	// 	font: 'Small',
-	// });
-	console.log(loadScaffoldDependencies());
+  // const text = figlet.textSync('HEllO !', {
+  // 	font: 'Small',
+  // });
+  console.log(loadScaffoldDependencies());
 };

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,62 +1,59 @@
-import ora from "ora"
-import { Command } from "commander"
-import { execa } from "execa"
-import { detect } from "@antfu/ni"
-import path from 'path'; 
-
-
+import ora from "ora";
+import { Command } from "commander";
+import { execa } from "execa";
+import { detect } from "@antfu/ni";
+import path from "path";
+import fs from "fs";
 
 export async function getPackageManager(
-    targetDir: string
-  ): Promise<"yarn" | "pnpm" | "bun" | "npm"> {
-    const packageManager = await detect({ programmatic: true, cwd: targetDir })
-  
-    if (packageManager === "yarn@berry") return "yarn"
-    if (packageManager === "pnpm@6") return "pnpm"
-    if (packageManager === "bun") return "bun"
-  
-    return packageManager ?? "npm"
-  }
+  targetDir: string
+): Promise<"yarn" | "pnpm" | "bun" | "npm"> {
+  const packageManager = await detect({ programmatic: true, cwd: targetDir });
+
+  if (packageManager === "yarn@berry") return "yarn";
+  if (packageManager === "pnpm@6") return "pnpm";
+  if (packageManager === "bun") return "bun";
+  console.log(`detected ${packageManager ?? "npm"} package manager`);
+  return packageManager ?? "npm";
+}
 
 export const init = new Command()
-    .name("init")
-    .description("install dependencies")
-    .option(
-        "-c, --cwd <cwd>",
-        "the working directory. defaults to the current directory.",
-        process.cwd()
-    )
-    .action(async ({ cwd }: { cwd: string }) => {
-        try {
-            await runInit(cwd);
-        } catch (error) {
-            console.error("Initialization failed:", error);
-            process.exit(1);
-        }
-    });
+  .name("init")
+  .description("install dependencies")
+  .option(
+    "-c, --cwd <cwd>",
+    "the working directory. defaults to the current directory.",
+    process.cwd()
+  )
+  .action(async ({ cwd }: { cwd: string }) => {
+    try {
+      await runInit(cwd);
+    } catch (error) {
+      console.error("Initialization failed:", error);
+      process.exit(1);
+    }
+  });
 
 async function loadScaffoldDependencies(): Promise<string[]> {
-  const packageJsonPath = path.join(process.cwd(), 'package.json'); 
-  const packageJson = await import(packageJsonPath);
+  const packageJsonPath = path.join(process.cwd(), "package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
   return Object.keys(packageJson.dependencies);
 }
 
 export async function runInit(cwd: string) {
-    const dependenciesSpinner = ora(`Installing dependencies...`)?.start()
-    const packageManager = await getPackageManager(cwd)
+  const dependenciesSpinner = ora(`Installing dependencies...`)?.start();
+  const packageManager = await getPackageManager(cwd);
 
-    const scaffoldDependencies = await loadScaffoldDependencies()
+  const scaffoldDependencies = await loadScaffoldDependencies();
 
-    const deps = [
-        ...scaffoldDependencies,
-    ]
+  const deps = [...scaffoldDependencies];
 
-    await execa(
-        packageManager,
-        [packageManager === "npm" ? "install" : "add", ...deps],
-        {
-        cwd,
-        }
-    )
-    dependenciesSpinner?.succeed()
+  await execa(
+    packageManager,
+    [packageManager === "npm" ? "install" : "add", ...deps],
+    {
+      cwd,
+    }
+  );
+  dependenciesSpinner?.succeed();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,7 @@ import { helloCommand } from "./commands/hello.js"
 			'-v, --version',
 			'display the version number',
 		);
-	
+		
 	program.addCommand(init).addCommand(helloCommand)
 	program.parse()
-
 })();


### PR DESCRIPTION
Problem: 
cli was having trouble resolving the package.json file type because it was being imported using the `import await` syntax. This was causing the file to be loaded as a `module` and not as a simple json file.

Solution:
Remove the `import await` syntax
perfers: using fs and path to resolve the current working directory and parse the file as json with JSON.parse.